### PR TITLE
Help page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13733,6 +13733,11 @@
       "integrity": "sha512-4gDntzrifFnCEvyoO8PqyJDmguXgVPxKiIxrBKjIowvL9l+N66196+72XVYR8BBf1Uv1Fgt3bGevJ+sEmxfZzw==",
       "dev": true
     },
+    "vue-youtube-embed": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/vue-youtube-embed/-/vue-youtube-embed-2.2.2.tgz",
+      "integrity": "sha512-l/EJuFMRK43AN73N+qxJnN0LB3uPl2xAghmr3dCvODWGCRWGjmGfrHaOtD93fu9J4co+CZLv1KP3akAsldC1aw=="
+    },
     "vuelidate": {
       "version": "0.7.5",
       "resolved": "https://registry.npmjs.org/vuelidate/-/vuelidate-0.7.5.tgz",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "vue": "^2.6.10",
     "vue-global-events": "^1.1.2",
     "vue-router": "^3.1.5",
+    "vue-youtube-embed": "^2.2.2",
     "vuelidate": "^0.7.5",
     "vuex": "^3.1.3"
   },

--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -7,19 +7,13 @@
       <ion-icon name="quote"></ion-icon>
     </router-link>
     <router-link to="help" class="choice">
-      <ion-icon name="help" @click="openTutorial"></ion-icon>
+      <ion-icon name="help"></ion-icon>
     </router-link>
   </div>
 </template>
 
 <script>
-export default {
-  methods: {
-    openTutorial() {
-      window.open("https://youtu.be/3lczVrzJcEg", "_blank");
-    }
-  }
-};
+
 </script>
 
 <style lang="scss">

--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,9 @@ import router from "./router";
 import store from "./store";
 import "@/modules/axios-config";
 import Vuelidate from "vuelidate";
+import VueYouTubeEmbed from "vue-youtube-embed";
 Vue.use(Vuelidate);
+Vue.use(VueYouTubeEmbed);
 
 Vue.config.productionTip = false;
 Vue.config.ignoredElements = [/^ion-/];

--- a/src/router/index.js
+++ b/src/router/index.js
@@ -35,6 +35,12 @@ const routes = [
       import(/* webpackChunkName: "recents" */ "../views/Phrases.vue")
   },
   {
+    path: "/help",
+    name: "help",
+    component: () =>
+      import(/* webpackChunkName: "recents" */ "../views/Help.vue")
+  },
+  {
     path: "*",
     name: "default",
     component: Record

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -1,13 +1,46 @@
 <template>
   <div class="help page">
     <div class="content">
-      <h1 class="title">Help</h1>
+      <h1 class="title">Tutorial</h1>
+        <div class="youtube-media">
+          <youtube
+            :video-id="videoId"
+            :player-width="mediaWidth"
+            :player-height="mediaHeight"
+            host="https://www.youtube-nocookie.com">
+          </youtube>
+        </div>
+        <div class="description">
+          <p>Thanks for taking interest in helping NIMBUS learn.</p>
+          <p>{{ recorderDescriptionText }}</p>
+          <p>{{ phraseDescriptionText }}</p>
+          <p>Thanks for contributing to the CSAI NIMBUS project!</p>
+        </div>
     </div>
   </div>
 </template>
 
 <script>
-  
+import { getIdFromURL } from "vue-youtube-embed";
+export default {
+  data() {
+    return {
+      videoId: getIdFromURL("https://youtu.be/3lczVrzJcEg"),
+      viewportWidth: Math.max(document.documentElement.clientWidth, window.innerWidth || 0),
+      viewportHeight: Math.max(document.documentElement.clientHeight, window.innerHeight || 0) - 65,
+      recorderDescriptionText: "On the Recorder page, you help NIMBUS learn to recognize its spoken name. Simply press the microphone icon and follow the verbal prompt. Next, type in your information to help Nimbus distinguish different audio contexts. Then you may either press 'Done' or 'Record Again', which will temporarily keep your information for the next recording. Try clicking the refresh icon above the mic to teach NIMBUS words that sound similar to its name!",
+      phraseDescriptionText: "On the Phrases page, you help NIMBUS learn to interpret written text. Enter a question/answer pair and click 'Tokenize'. Then combine any related adjacent words into tokens and label them with the categories provided. (Or create your own!)"
+    }
+  },
+  computed: {
+    mediaWidth() {
+      return this.viewportWidth > 690 ? 690 : this.viewportWidth;
+    },
+    mediaHeight() {
+      return this.viewportHeight > 388.125 ? 388.125 : this.viewportHeight;
+    }
+  }
+};
 </script>
 
 <style lang="scss">
@@ -15,6 +48,19 @@
   .content {
     .title {
       margin: 20px 0;
+    }
+    .youtube-media {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      width: 100%;
+    }
+    .description {
+      margin-top: 15px;
+      margin-bottom: 100px;
+      p {
+        padding-bottom: 10px;
+      }
     }
   }
 }

--- a/src/views/Help.vue
+++ b/src/views/Help.vue
@@ -1,0 +1,21 @@
+<template>
+  <div class="help page">
+    <div class="content">
+      <h1 class="title">Help</h1>
+    </div>
+  </div>
+</template>
+
+<script>
+  
+</script>
+
+<style lang="scss">
+.help {
+  .content {
+    .title {
+      margin: 20px 0;
+    }
+  }
+}
+</style>


### PR DESCRIPTION
I added a help page with the YouTube tutorial for CSAI Recorder embedded, with some descriptive text below it. This page appears when the "?" is clicked in the menu bar. This page replaces the previous functionality of the "?" icon, which was to open the video in a new tab in YouTube. This page appears to work and look ok in Chrome (both desktop and mobile), but I have not tried it in other browsers. The video was embedded using the [vue-youtube-embed component](https://www.npmjs.com/package/vue-youtube-embed). I believe I added the npm dependencies to the project correctly (because the page works properly), but it's worth double checking.