### PR TITLE
Hover effects for menu bar buttons

### DIFF
--- a/src/components/Menu.vue
+++ b/src/components/Menu.vue
@@ -1,13 +1,19 @@
 <template>
   <div class="menu">
     <router-link to="record" class="choice">
-      <ion-icon name="mic"></ion-icon>
+      <div class="iconBox">
+        <ion-icon name="mic"></ion-icon>
+      </div>
     </router-link>
     <router-link to="phrases" class="choice">
-      <ion-icon name="quote"></ion-icon>
+      <div class="iconBox">
+        <ion-icon name="quote"></ion-icon>
+      </div>
     </router-link>
     <router-link to="help" class="choice">
-      <ion-icon name="help"></ion-icon>
+      <div class="iconBox">
+        <ion-icon name="help"></ion-icon>
+      </div>
     </router-link>
   </div>
 </template>
@@ -30,11 +36,26 @@
   box-shadow: 0px 0 30px rgba(0, 0, 0, 0.164);
   padding: 10px 20px;
 
-  ion-icon {
-    height: 40px;
-    margin: auto;
+  .iconBox {
+    height: var(--menu-height);
+    width: 80px;
+    display: flex;
+    justify-content: center;
+    align-items: center;
     padding: 0;
-    fill: white;
+
+    ion-icon {
+      height: 40px;
+      margin: auto;
+      padding: 0;
+      fill: white;
+    }
+
+    @media(hover: hover) and (pointer: fine) {
+      &:hover {
+        background: rgba(255, 255, 255, 0.1);
+      }
+    }
   }
 
   .choice {
@@ -43,7 +64,7 @@
     display: block;
     color: white;
     transition: opacity 0.5s, transform 0.5s;
-    padding: 0 20px;
+    padding: 0;
 
     &:active {
       transform: scale(0.95);


### PR DESCRIPTION
Added hover effects to the menu buttons, for desktop use. I tested this on iOS for Chrome, Safari, and Firefox mobile browsers and the buttons don't get stuck in a hover state for these apps. Testing on Android or other mobile browsers might be a good idea.